### PR TITLE
Allow ?si= to be play able too

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -117,7 +117,7 @@ export class Spotify extends Plugin {
 
     private async search(query: string | SearchQuery, requester?: unknown): Promise<SearchResult> {
         const finalQuery = (query as SearchQuery).query || query as string;
-        const [ , type, id ] = finalQuery.match(REGEX) ?? [];
+        const [ , type, id ] = finalQuery.split("?si=")[0].match(REGEX) ?? [];
 
         if (type in this.functions) {
             try {


### PR DESCRIPTION
This allows tracks or playlists having a: ?si=e2ee7951fa904de2 afterwards like this one: https://open.spotify.com/track/1blKoGhav3B6UXu7RsuNXg?si=e2ee7951fa904de2 to be played too! Idk typscript so i did it with basic .split("?si=")[0] but yeeeaa