### PR TITLE
fix(fetch): spotify url generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erela.js-spotify",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Spotify plugin for Erela.JS",
   "main": "dist/index.js",
   "files": [

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -157,7 +157,7 @@ export class Spotify extends Plugin {
     }
 
     private async getAlbumTracks(id: string): Promise<Result> {
-        const album = await this.makeRequest<Album>(`${BASE_URL}/albums/${id}`)
+        const album = await this.makeRequest<Album>(`albums/${id}`)
         const tracks = album.tracks.items.filter(this.filterNullOrUndefined).map(item => Spotify.convertToUnresolved(item));
         let next = album.tracks.next, page = 1;
 
@@ -172,7 +172,7 @@ export class Spotify extends Plugin {
     }
 
     private async getPlaylistTracks(id: string): Promise<Result> {
-        const playlist = await this.makeRequest<Playlist>(`${BASE_URL}/playlists/${id}`);
+        const playlist = await this.makeRequest<Playlist>(`playlists/${id}`);
         const tracks = playlist.tracks.items.filter(this.filterNullOrUndefined).map(item => Spotify.convertToUnresolved(item.track));
         let next = playlist.tracks.next, page = 1;
 
@@ -187,7 +187,7 @@ export class Spotify extends Plugin {
     }
 
     private async getTrack(id: string): Promise<Result> {
-        const data = await this.makeRequest<SpotifyTrack>(`${BASE_URL}/tracks/${id}`);
+        const data = await this.makeRequest<SpotifyTrack>(`tracks/${id}`);
         const track = Spotify.convertToUnresolved(data);
         return { tracks: [ track ] };
     }


### PR DESCRIPTION
Hi, thanks for these amazing packages.

Seems like the package published at [NPM](https://www.npmjs.com/package/erela.js-spotify) is not up to date with the master branch of this repo. Thus, I'm using this package like below:
```json
"dependencies": {
    ...
    "erela.js-spotify": "https://github.com/MenuDocs/erela.js-spotify#build",
    ...
  }
```

---

Adding Spotify links to the queue failed, and upon initial investigation:
```javascript
{
  loadType: 'LOAD_FAILED',
  tracks: [],
  playlist: null,
  exception: {
    message: 'The track artists array was not provided',
    severity: 'COMMON'
  }
}
```

That led to
```javascript
{ error: { status: 404, message: 'Service not found' } }
```

Eventually I found out that the `BASE_URL` in `fetch` was "generated" twice
```javascript
{
  coreOptions: {},
  httpMethod: 'GET',
  reqHeaders: {
    authorization: 'Bearer <token>'
  },
  timeoutOptions: {},
  url: URL {
    href: 'https://api.spotify.com/v1/https://api.spotify.com/v1/tracks/2vzpoecVhBE1pKtHzKONaN',
    origin: 'https://api.spotify.com',
    protocol: 'https:',
    username: '',
    password: '',
    host: 'api.spotify.com',
    hostname: 'api.spotify.com',
    port: '',
    pathname: '/v1/https://api.spotify.com/v1/tracks/2vzpoecVhBE1pKtHzKONaN',
    search: '',
    searchParams: URLSearchParams {},
    hash: ''
  }
}
```

This PR fixed the URL generation
```javascript
{
  coreOptions: {},
  httpMethod: 'GET',
  reqHeaders: {
    authorization: 'Bearer <token>'
  },
  timeoutOptions: {},
  url: URL {
    href: 'https://api.spotify.com/v1/tracks/2vzpoecVhBE1pKtHzKONaN',
    origin: 'https://api.spotify.com',
    protocol: 'https:',
    username: '',
    password: '',
    host: 'api.spotify.com',
    hostname: 'api.spotify.com',
    port: '',
    pathname: '/v1/tracks/2vzpoecVhBE1pKtHzKONaN',
    search: '',
    searchParams: URLSearchParams {},
    hash: ''
  }
}
```

And I have tested this with Spotify Track URL, Album URL, and Playlist URL.
All tracks were successfully loaded and successfully played.

Some additional environment info:
- Node.js v16.11.0
- Discord.js v13.2.0
- erela.js v2.3.3